### PR TITLE
make "all in ram" option default

### DIFF
--- a/iso_templ/boot/grub/grub.cfg.pldnrt
+++ b/iso_templ/boot/grub/grub.cfg.pldnrt
@@ -189,22 +189,23 @@ function other_menuentry {
 
 for bits in 64 32 ; do
     pldnr_menuentry \
+                "PLD New Rescue $bits (all in RAM)" \
+                yes $bits "base basic rescue"
+
+    pldnr_menuentry \
                 "PLD New Rescue $bits (minimum RAM)" \
                 iscsi $bits ""
 
     pldnr_menuentry \
-                "PLD New Rescue $bits (all in RAM)" \
-                yes $bits "base basic rescue"
+                "PLD New Rescue $bits (serial console, all in RAM)" \
+                yes $bits "base basic rescue" \
+                "console=tty0 console=ttyS0,115200n8 earlyprintk=serial,ttyS0,115200"
 
     pldnr_menuentry \
                 "PLD New Rescue $bits (serial console, minimum RAM)" \
                 iscsi $bits "" \
                 "console=tty0 console=ttyS0,115200n8 earlyprintk=serial,ttyS0,115200"
 
-    pldnr_menuentry \
-                "PLD New Rescue $bits (serial console, all in RAM)" \
-                yes $bits "base basic rescue" \
-                "console=tty0 console=ttyS0,115200n8 earlyprintk=serial,ttyS0,115200"
 done
 
 if [ "$grub_platform" = "efi" ] ; then


### PR DESCRIPTION
rationale:
- it is unclear how much ram is needed in "minimum" mode (256MB?)
  vs "all in ram" (512MB/1G?)
- most likely most computers have enough ram for "all in ram" mode
- "minimum" does not always boot properly (noticed issues when booting
  from USB or from VM guest), "all in RAM" works much better.